### PR TITLE
feat: add ARMv8 docker support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,4 +27,4 @@ jobs:
         with:
           push: true
           tags: amm0nite/mqtt2http:latest
-          platforms: linux/amd64, linux/arm/v7
+          platforms: linux/amd64, linux/arm/v7, linux/arm/v8


### PR DESCRIPTION
Currently there are only x86 and armv7 images published, it would be great to have v8 images too.